### PR TITLE
 add metrics scraping points for attacher and snapshotter

### DIFF
--- a/charts/nutanix-csi-storage/templates/service-prometheus-csi.yaml
+++ b/charts/nutanix-csi-storage/templates/service-prometheus-csi.yaml
@@ -19,7 +19,6 @@ spec:
       port: 9809
       targetPort: 9809
       protocol: TCP
-    #This should be attacher instead of resizer
     - name: attacher
       port: 9810
       targetPort: 9810

--- a/charts/nutanix-csi-storage/templates/service-prometheus-csi.yaml
+++ b/charts/nutanix-csi-storage/templates/service-prometheus-csi.yaml
@@ -19,9 +19,18 @@ spec:
       port: 9809
       targetPort: 9809
       protocol: TCP
-    - name: resizer
+    #This should be attacher instead of resizer
+    - name: attacher
       port: 9810
       targetPort: 9810
+      protocol: TCP
+    - name: resizer
+      port: 9811
+      targetPort: 9811
+      protocol: TCP
+    - name: snapshotter
+      port: 9812
+      targetPort: 9812
       protocol: TCP
 {{- if eq .Values.servicemonitor.enabled true }}
 ---
@@ -40,6 +49,10 @@ spec:
     port: provisioner
   - interval: 30s
     port: resizer
+  - interval: 30s
+    port: attacher
+  - interval: 30s
+    port: snapshotter
   selector:
     matchLabels:
       app: csi-provisioner-ntnx-plugin


### PR DESCRIPTION
In the service monitor added the ports of the services from which prometheus will get attacher and snapshotter metrics