### PR TITLE
[ENG-577579] - add commands to check status of pods after deployment

### DIFF
--- a/charts/nutanix-csi-storage/templates/NOTES.txt
+++ b/charts/nutanix-csi-storage/templates/NOTES.txt
@@ -1,3 +1,4 @@
 Driver name: {{ include "nutanix-csi-storage.drivername" . }}
 
-Nutanix CSI provider was deployed in namespace {{ .Release.Namespace }}
+Nutanix CSI provider was deployed in namespace {{ .Release.Namespace }}. Check it's status by running:
+kubectl -n {{ .Release.Namespace }} get pods | grep 'nutanix-csi'


### PR DESCRIPTION
After CSI installation using helm, a message is displayed with installation info. It will now contain a command that can be run to see status of pods part of the CSI storage release.