### PR TITLE
[ENG-583629] - increase timeouts for side car containers

### DIFF
--- a/charts/nutanix-csi-storage/templates/ntnx-csi-controller-deployment.yaml
+++ b/charts/nutanix-csi-storage/templates/ntnx-csi-controller-deployment.yaml
@@ -45,7 +45,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             - --csi-address=$(ADDRESS)
-            - --timeout=60s
+            - --timeout=300s
             - --worker-threads=16
             # This adds PV/PVC metadata to create volume requests
             - --extra-create-metadata=true
@@ -73,7 +73,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           args:
             - --csi-address=$(ADDRESS)
-            - --timeout=60s
+            - --timeout=300s
             - --worker-threads=16
             - --http-endpoint=:9810
             - --v=2
@@ -97,7 +97,7 @@ spec:
           args:
             - --v=2
             - --csi-address=$(ADDRESS)
-            - --timeout=60s
+            - --timeout=300s
             - --leader-election=true
             # NTNX CSI dirver supports online volume expansion.
             - --handle-volume-inuse-error=false


### PR DESCRIPTION
PV creation is taking more than 1 minute in certain cases. Hence, increased the timeout to 300s for csi-provisioner sidecar container and other sidecars also.